### PR TITLE
added scrollOverflow parameter

### DIFF
--- a/lib/bidirectional_scroll_view.dart
+++ b/lib/bidirectional_scroll_view.dart
@@ -2,19 +2,24 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
 class BidirectionalScrollViewPlugin extends StatefulWidget {
-  BidirectionalScrollViewPlugin({@required this.child,
-    this.velocityFactor, this.scrollListener});
+  BidirectionalScrollViewPlugin({
+    @required this.child,
+    this.velocityFactor,
+    this.scrollListener,
+    this.scrollOverflow = Overflow.visible,
+  });
 
   final Widget child;
   final double velocityFactor;
   final ValueChanged<Offset> scrollListener;
+  final Overflow scrollOverflow;
 
   _BidirectionalScrollViewState _state;
 
   @override
   State<StatefulWidget> createState() {
-    _state = new _BidirectionalScrollViewState(child, velocityFactor,
-        scrollListener);
+    _state = new _BidirectionalScrollViewState(
+        child, velocityFactor, scrollListener);
     return _state;
   }
 
@@ -127,7 +132,8 @@ class _BidirectionalScrollViewState extends State<BidirectionalScrollViewPlugin>
   }
 
   void _handleFlingAnimation() {
-    if (!_enableFling || _flingAnimation.value.dx.isNaN ||
+    if (!_enableFling ||
+        _flingAnimation.value.dx.isNaN ||
         _flingAnimation.value.dy.isNaN) {
       return;
     }
@@ -165,7 +171,6 @@ class _BidirectionalScrollViewState extends State<BidirectionalScrollViewPlugin>
     RenderBox containerBox = _containerKey.currentContext.findRenderObject();
     double containerWidth = containerBox.size.width;
     double containerHeight = containerBox.size.height;
-
 
     if (newXPosition > 0.0 || width < containerWidth) {
       newXPosition = 0.0;
@@ -211,9 +216,9 @@ class _BidirectionalScrollViewState extends State<BidirectionalScrollViewPlugin>
 
     _enableFling = true;
     _flingAnimation = new Tween<Offset>(
-        begin: new Offset(0.0, 0.0),
-        end: direction * distance * _velocityFactor
-    ).animate(_controller);
+            begin: new Offset(0.0, 0.0),
+            end: direction * distance * _velocityFactor)
+        .animate(_controller);
     _controller
       ..value = 0.0
       ..fling(velocity: velocity);
@@ -232,18 +237,17 @@ class _BidirectionalScrollViewState extends State<BidirectionalScrollViewPlugin>
       onPanUpdate: _handlePanUpdate,
       onPanEnd: _handlePanEnd,
       child: new Container(
-          key: _containerKey,
-          child: new Stack(
-            overflow: Overflow.visible,
-            children: <Widget>[
-              new Positioned(
-                  key: _positionedKey,
-                  top: yViewPos,
-                  left: xViewPos,
-                  child: _child
-              ),
-            ],
-          )
+        key: _containerKey,
+        child: new Stack(
+          overflow: widget.scrollOverflow,
+          children: <Widget>[
+            new Positioned(
+                key: _positionedKey,
+                top: yViewPos,
+                left: xViewPos,
+                child: _child),
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bidirectional_scroll_view
 description: Plugin that provides a bidirectional scrollview.
-version: 0.0.6
+version: 0.0.7
 author: Toufik Zitouni <toufiksapps@gmail.com>
 homepage: https://github.com/toufikzitouni/flutter-bidirectional_scrollview_plugin
 
@@ -14,5 +14,5 @@ dependencies:
     sdk: flutter
 
 environment:
-  sdk: '>=1.19.0 <2.1.0'
-  flutter: '>=0.1.0 <2.0.0'
+  sdk: '>=2.0.0-dev.28.0 <3.0.0'
+  flutter: '>=0.1.4 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bidirectional_scroll_view
 description: Plugin that provides a bidirectional scrollview.
-version: 0.0.7
+version: 0.0.8
 author: Toufik Zitouni <toufiksapps@gmail.com>
 homepage: https://github.com/toufikzitouni/flutter-bidirectional_scrollview_plugin
 


### PR DESCRIPTION
This new parameter lets you specify how the Stack should handle an overflow. This occurs when the parent widget of the `BidirectionalScrollViewPlugin` doesn't occupy the whole scree. I defaulted it to `Overflow.visible ` to make it a non-breaking change.